### PR TITLE
Support explicitly setting pointer tag to zero

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -113,7 +113,13 @@ const TagCoder: P.Coder<TagRaw[], Tags> = {
         for (const p of to.parent) res.push({ tag: tagName, data: TagCoders.parent.encode(p) });
         continue;
       }
-      const bytes = TagCoders[field as TagName].encode(to[field as TagName]);
+      let bytes = TagCoders[field as TagName].encode(to[field as TagName]);
+
+      // Handle pointer = 0:
+      if (field === 'pointer' && bytes.length === 0) {
+        bytes = new Uint8Array([0]);
+      }
+
       for (const data of splitChunks(bytes)) res.push({ tag: tagName, data });
     }
     if (to.unknown) {

--- a/test/ordinals.test.js
+++ b/test/ordinals.test.js
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from 'node:assert';
+import { deepStrictEqual, strictEqual } from 'node:assert';
 import { describe, should } from 'micro-should';
 import { hex, utf8 } from '@scure/base';
 import * as btc from '@scure/btc-signer';
@@ -66,6 +66,17 @@ describe('Ordinals', () => {
       deepStrictEqual(TagCoder.encode(TagCoder.decode({ parent: vector })), { parent: vector });
     });
   });
+
+  should('support explicit pointer 0', () => {
+    const { TagCoder } = ordinals.__test__;
+    const encoded = TagCoder.decode({ pointer: 0n });
+
+    const encodedTag = encoded[0].tag[0]
+    const encodedValue = encoded[0].data[0]
+
+    strictEqual(encodedTag, 2);
+    strictEqual(encodedValue, 0);
+  })
 
   should('inscription/11820782', () => {
     // https://ordiscan.com/inscription/11820782


### PR DESCRIPTION
I noticed that if you try creating an inscription where you explicitly want the pointer to be 0, like this:

```ts
const inscription: Inscription = {
  tags: {
    contentType,
    pointer: 0n,
  },
  body,
};

p2tr_ord_reveal(u8RevealPublicKey, [inscription]);
```

...the library will simply ignore the pointer tag and not encode it (presumably because it's assumed to be the default?)

However, being able to explicitly define a pointer of 0 is very useful in cases where you want to inscribe something on a rare sat, where the first input might not contain the inscription witness.

Below is an example transaction. If `pointer: 0` wasn't set, the inscription would be made on the first sat of the remaining fee output, instead of on the rare sat: 
https://ordiscan.com/tx/bd63b470242919cbd32de382ba91d2f5140d5296dc2d0ff2c7c8a3deaaa387c1

![CleanShot 2024-12-22 at 10 05 56@2x](https://github.com/user-attachments/assets/4e96823f-e7e0-4c58-bb26-cbeb588911ac)

I made a quick fix for this and wrote a simple test for it, but there might be a more elegant way of solving this.